### PR TITLE
Log SNCF API error body

### DIFF
--- a/app/api/trains/route.ts
+++ b/app/api/trains/route.ts
@@ -67,7 +67,8 @@ export async function GET() {
     })
 
     if (!response.ok) {
-      console.error(`SNCF API error: ${response.status} - ${response.statusText}`)
+      const errBody = await response.text()
+      console.error("SNCF API error:", response.status, errBody)
       throw new Error(`SNCF API error: ${response.status}`)
     }
 


### PR DESCRIPTION
## Summary
- log SNCF API response body and status before throwing errors

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: requires interactive ESLint setup)


------
https://chatgpt.com/codex/tasks/task_e_68b9a18ee7b8832f90bfa588bc7c7036