### PR TITLE
Use Basic auth for SNCF API requests

### DIFF
--- a/app/api/trains/route.ts
+++ b/app/api/trains/route.ts
@@ -57,11 +57,13 @@ export async function GET() {
       return NextResponse.json({ error: "API key not configured" }, { status: 500 })
     }
 
+    const authHeader = "Basic " + Buffer.from(`${apiKey}:`).toString("base64")
+
     const url = `${SNCF_API_BASE}/coverage/${COVERAGE}/stop_areas/${STOP_AREA_ID}/departures?count=10&data_freshness=realtime`
 
     const response = await fetch(url, {
       headers: {
-        Authorization: apiKey,
+        Authorization: authHeader,
         Accept: "application/json",
       },
     })


### PR DESCRIPTION
## Summary
- encode SNCF API key and send as Basic auth header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive ESLint configuration prompt)*
- `npm run build` *(fails: build did not complete in time)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a1a2cecc832fb85d20ac054b3bca