### PR TITLE
feat: use official sncf journeys api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # RER C Schedule App
 
-new version based on V0.app
+Simple Next.js application that displays upcoming RER C departures.
+
+This version queries the official SNCF API using the `journeys` endpoint:
+`https://api.sncf.com/v1/coverage/sncf/journeys`.

--- a/app/api/trains/route.ts
+++ b/app/api/trains/route.ts
@@ -1,49 +1,45 @@
 import { NextResponse } from "next/server"
 
-const SNCF_API_BASE = "https://api.navitia.io/v1"
-const COVERAGE = "fr-idf"
-const STOP_AREA_ID = "stop_area:OCE:SA:87758011" // Issy - Val de Seine
+const SNCF_API_BASE = "https://api.sncf.com/v1"
+const FROM_STOP_AREA = "stop_area:OCE:SA:87758011" // Issy - Val de Seine
+const TO_STOP_AREA = "stop_area:OCE:SA:87393009" // Versailles Rive Gauche
 
-interface NavitiaResponse {
-  departures: Array<{
-    stop_date_time: {
+interface SNCFJourneysResponse {
+  journeys: Array<{
+    sections: Array<{
+      type: string
       departure_date_time: string
-      data_freshness: string
-    }
-    display_informations: {
-      headsign: string
-      network: string
-      direction: string
-      commercial_mode: string
-      physical_mode: string
-      label: string
-      color: string
-      code: string
-    }
-    route: {
-      name: string
-      id: string
-    }
-    stop_point: {
-      name: string
-    }
+      arrival_date_time: string
+      display_informations?: {
+        headsign: string
+        network: string
+        direction: string
+        commercial_mode: string
+        physical_mode: string
+        label: string
+        color: string
+        code: string
+      }
+    }>
   }>
 }
 
-function generateMissionCode(destination: string, index: number): string {
-  const missions = ["VICK", "VERO", "VALI", "VIAN", "VICT", "VEGA"]
-  return missions[index % missions.length]
-}
-
 function parseDateTime(dateTimeStr: string): { time: string; delay: number } {
-  const date = new Date(dateTimeStr)
+  const match = dateTimeStr.match(
+    /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})/
+  )
+  if (!match) {
+    return { time: "", delay: 0 }
+  }
+  const [, y, m, d, h, min, s] = match
+  const date = new Date(`${y}-${m}-${d}T${h}:${min}:${s}`)
   const time = date.toLocaleTimeString("fr-FR", {
     hour: "2-digit",
     minute: "2-digit",
   })
 
-  // Calculate delay (simplified - in real implementation, compare with scheduled time)
-  const delay = Math.random() > 0.7 ? Math.floor(Math.random() * 8) : 0
+  // Delay information not provided by the API in this endpoint
+  const delay = 0
 
   return { time, delay }
 }
@@ -59,7 +55,7 @@ export async function GET() {
 
     const authHeader = "Basic " + Buffer.from(`${apiKey}:`).toString("base64")
 
-    const url = `${SNCF_API_BASE}/coverage/${COVERAGE}/stop_areas/${STOP_AREA_ID}/departures?count=10&data_freshness=realtime`
+    const url = `${SNCF_API_BASE}/coverage/sncf/journeys?from=${FROM_STOP_AREA}&to=${TO_STOP_AREA}&count=6`
 
     const response = await fetch(url, {
       headers: {
@@ -74,23 +70,23 @@ export async function GET() {
       throw new Error(`SNCF API error: ${response.status}`)
     }
 
-    const data: NavitiaResponse = await response.json()
+    const data: SNCFJourneysResponse = await response.json()
 
-    const departures = data.departures
-      .filter((dep) => dep.display_informations.network === "RER" && dep.display_informations.code === "C")
-      .slice(0, 6)
-      .map((departure, index) => {
-        const { time, delay } = parseDateTime(departure.stop_date_time.departure_date_time)
-        const mission = generateMissionCode(departure.display_informations.direction, index)
+    const departures = data.journeys
+      .map((journey, index) => {
+        const ptSection = journey.sections.find((s) => s.type === "public_transport")
+        if (!ptSection || !ptSection.display_informations) return null
+        const { time, delay } = parseDateTime(ptSection.departure_date_time)
 
         return {
           time,
-          destination: departure.display_informations.direction || "Versailles Rive Gauche",
-          mission,
+          destination: ptSection.display_informations.direction || "Destination inconnue",
+          mission: ptSection.display_informations.code || `M${index + 1}`,
           delay,
           status: delay > 0 ? ("delayed" as const) : ("on-time" as const),
         }
       })
+      .filter(Boolean)
 
     return NextResponse.json({ departures })
   } catch (error) {


### PR DESCRIPTION
## Summary
- switch train schedule API calls to official SNCF journeys endpoint
- document SNCF journeys API usage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b05a31c4832fbd8fdf7e09d9dd86