### PR TITLE
Disable fetch caching for SNCF API and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ Simple Next.js application that displays upcoming RER C departures.
 This version queries the official SNCF API using the `journeys` endpoint:
 `https://api.sncf.com/v1/coverage/sncf/journeys`.
 
+## Caching
+
+API requests are explicitly executed with `cache: "no-store"` to ensure every
+call hits the live SNCF service and always returns fresh data. This means no
+server-side caching is performed, which could increase the number of requests
+in production.
+
 ## Environment variables
 
 - `SNCF_API_KEY` `: SNCF API key.

--- a/app/api/trains/route.ts
+++ b/app/api/trains/route.ts
@@ -65,6 +65,7 @@ export async function GET() {
         Authorization: authHeader,
         Accept: "application/json",
       },
+      cache: "no-store",
     })
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- disable caching on SNCF API fetch using `cache: "no-store"`
- document the lack of caching in the README

## Testing
- `curl -i 'https://api.sncf.com/v1/coverage/sncf/journeys?from=stop_area:SNCF:87271007&to=stop_area:SNCF:87393157&count=6&datetime_represents=departure'` (fails: 403 Forbidden)
- `pnpm lint` (fails: command prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68bb34575f40832fb357481000cdc4fd