### PR TITLE
Fetch upcoming direct RER C journeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # RER C Schedule App
 
-Simple Next.js application that displays upcoming RER C departures.
+Simple Next.js application that displays the next direct RER C trains
+from Issy-Val-de-Seine to Versailles Château Rive Gauche.
 
 This version queries the official SNCF API using the `journeys` endpoint:
-`https://api.sncf.com/v1/coverage/sncf/journeys`.
+`https://api.sncf.com/v1/coverage/sncf/journeys` with `allowed_id[]=line:SNCF:C`.
 
 ## Caching
 
@@ -14,5 +15,5 @@ in production.
 
 ## Environment variables
 
-- `SNCF_API_KEY` `: SNCF API key.
+- `SNCF_API_KEY` : API key for api.sncf.com.
 

--- a/app/api/trains/route.ts
+++ b/app/api/trains/route.ts
@@ -1,53 +1,68 @@
 import { NextResponse } from "next/server"
 
 const SNCF_API_BASE = "https://api.sncf.com/v1"
-const FROM_STOP_AREA = "stop_area:SNCF:87271007" // Issy - Val de Seine
-const TO_STOP_AREA = "stop_area:SNCF:87393157" // Versailles Rive Gauche
+const FROM_STOP_AREA = "stop_area:SNCF:87393306" // Issy-Val-de-Seine (RER C)
+const TO_STOP_AREA = "stop_area:SNCF:87393157" // Versailles Château Rive Gauche
 
 interface SNCFJourneysResponse {
   journeys: Array<{
+    departure_date_time: string
+    arrival_date_time: string
+    duration: number
     sections: Array<{
       type: string
-      departure_date_time: string
-      arrival_date_time: string
       display_informations?: {
         headsign: string
-        network: string
-        direction: string
-        commercial_mode: string
-        physical_mode: string
         label: string
-        color: string
-        code: string
+        trip_short_name: string
       }
     }>
   }>
 }
 
-function parseDateTime(dateTimeStr: string): { time: string; delay: number } {
+function parseDateTime(dateTimeStr: string): { iso: string; time: string } {
   const match = dateTimeStr.match(
     /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})/
   )
   if (!match) {
-    return { time: "", delay: 0 }
+    return { iso: "", time: "" }
   }
   const [, y, m, d, h, min, s] = match
-  const date = new Date(`${y}-${m}-${d}T${h}:${min}:${s}`)
-  const time = date.toLocaleTimeString("fr-FR", {
+  const date = new Date(Date.UTC(+y, +m - 1, +d, +h, +min, +s))
+
+  const formatter = new Intl.DateTimeFormat("sv-SE", {
+    timeZone: "Europe/Paris",
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
     hour: "2-digit",
     minute: "2-digit",
+    second: "2-digit",
   })
-
-  // Delay information not provided by the API in this endpoint
-  const delay = 0
-
-  return { time, delay }
+  const parts = Object.fromEntries(
+    formatter.formatToParts(date).map((p) => [p.type, p.value])
+  )
+  const isoWithoutOffset = `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}`
+  const tzPart = new Intl.DateTimeFormat("en-US", {
+    timeZone: "Europe/Paris",
+    timeZoneName: "shortOffset",
+  })
+    .formatToParts(date)
+    .find((p) => p.type === "timeZoneName")?.value || "GMT+0"
+  const offsetMatch = tzPart.match(/GMT([+-])(\d{1,2})(?::(\d{2}))?/)
+  const sign = offsetMatch ? offsetMatch[1] : "+"
+  const hh = offsetMatch ? offsetMatch[2].padStart(2, "0") : "00"
+  const mm = offsetMatch && offsetMatch[3] ? offsetMatch[3].padStart(2, "0") : "00"
+  const iso = `${isoWithoutOffset}${sign}${hh}:${mm}`
+  const time = `${parts.hour}:${parts.minute}`
+  return { iso, time }
 }
 
 export async function GET() {
   let url = ""
   try {
-    const apiKey = process.env.SNCF_API_KEY || process.env.API_SNCF_KEY
+    const apiKey = process.env.SNCF_API_KEY
 
     if (!apiKey) {
       console.error("SNCF API key not found")
@@ -56,7 +71,7 @@ export async function GET() {
 
     const authHeader = "Basic " + Buffer.from(`${apiKey}:`).toString("base64")
 
-    url = `${SNCF_API_BASE}/coverage/sncf/journeys?from=${FROM_STOP_AREA}&to=${TO_STOP_AREA}&count=6&datetime_represents=departure`
+    url = `${SNCF_API_BASE}/coverage/sncf/journeys?from=${FROM_STOP_AREA}&to=${TO_STOP_AREA}&count=6&datetime_represents=departure&max_nb_transfers=0&allowed_id[]=line:SNCF:C&disable_geojson=true`
 
     console.log("SNCF API request URL:", url)
 
@@ -78,36 +93,28 @@ export async function GET() {
 
     const data: SNCFJourneysResponse = await response.json()
 
-    const departures = data.journeys
-      .map((journey, index) => {
+    const journeys = data.journeys
+      .map((journey) => {
         const ptSection = journey.sections.find((s) => s.type === "public_transport")
         if (!ptSection || !ptSection.display_informations) return null
 
-
-        console.log("Journey", index, {
-          departure: ptSection.departure_date_time,
-          arrival: ptSection.arrival_date_time,
-          direction: ptSection.display_informations.direction,
-          code: ptSection.display_informations.code,
-        })
-
-
-        const { time, delay } = parseDateTime(ptSection.departure_date_time)
+        const dep = parseDateTime(journey.departure_date_time)
+        const arr = parseDateTime(journey.arrival_date_time)
 
         return {
-          time,
-          destination: ptSection.display_informations.direction || "Destination inconnue",
-          mission: ptSection.display_informations.code || `M${index + 1}`,
-          delay,
-          status: delay > 0 ? ("delayed" as const) : ("on-time" as const),
+          mission: ptSection.display_informations.headsign,
+          line: ptSection.display_informations.label,
+          trip: ptSection.display_informations.trip_short_name,
+          departure: dep.iso,
+          departure_time: dep.time,
+          arrival: arr.iso,
+          arrival_time: arr.time,
+          duration_s: journey.duration,
         }
       })
       .filter(Boolean)
 
-    console.log("SNCF departures:", departures)
-
-
-    return NextResponse.json({ departures })
+    return NextResponse.json({ journeys })
   } catch (error) {
     console.error("Error fetching SNCF data:", error)
     const errorMessage =

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,19 +3,21 @@
 import { useState, useEffect } from "react"
 import { RefreshCw, Train } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 
-interface TrainDeparture {
-  time: string
-  destination: string
+interface TrainJourney {
   mission: string
-  delay: number
-  status: "on-time" | "delayed" | "cancelled"
+  line: string
+  trip: string
+  departure: string
+  departure_time: string
+  arrival: string
+  arrival_time: string
+  duration_s: number
 }
 
 export default function RERSchedule() {
-  const [departures, setDepartures] = useState<TrainDeparture[]>([])
+  const [journeys, setJourneys] = useState<TrainJourney[]>([])
   const [loading, setLoading] = useState(false)
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -27,17 +29,17 @@ export default function RERSchedule() {
       const response = await fetch("/api/trains")
       if (response.ok) {
         const data = await response.json()
-        setDepartures(data.departures)
+        setJourneys(data.journeys)
         setLastUpdate(new Date())
       } else {
         const data = await response.json().catch(() => null)
         setError(data?.error || "Erreur lors de la récupération des horaires")
-        setDepartures([])
+        setJourneys([])
       }
     } catch (error) {
       console.error("Error fetching departures:", error)
       setError("Erreur lors de la récupération des horaires")
-      setDepartures([])
+      setJourneys([])
     }
     setLoading(false)
   }
@@ -45,24 +47,6 @@ export default function RERSchedule() {
   useEffect(() => {
     fetchDepartures()
   }, [])
-
-  const getStatusBadge = (departure: TrainDeparture) => {
-    if (departure.status === "cancelled") {
-      return <Badge variant="destructive">Supprimé</Badge>
-    }
-    if (departure.delay > 0) {
-      return (
-        <Badge variant="secondary" className="bg-red-100 text-red-700">
-          +{departure.delay} min
-        </Badge>
-      )
-    }
-    return (
-      <Badge variant="secondary" className="bg-green-100 text-green-700">
-        À l'heure
-      </Badge>
-    )
-  }
 
   return (
     <div className="min-h-screen bg-gray-50 p-4">
@@ -74,7 +58,7 @@ export default function RERSchedule() {
               <Train className="h-6 w-6" />
               RER C
             </CardTitle>
-            <p className="text-purple-100 text-sm">Issy - Val de Seine → Versailles Rive Gauche</p>
+            <p className="text-purple-100 text-sm">Issy-Val-de-Seine → Versailles Château Rive Gauche</p>
           </CardHeader>
         </Card>
 
@@ -101,15 +85,17 @@ export default function RERSchedule() {
 
         {/* Departures List */}
         <div className="space-y-3">
-          {departures.map((departure, index) => (
+          {journeys.map((journey, index) => (
             <Card key={index} className="bg-white shadow-sm border border-gray-200">
               <CardContent className="p-4">
                 <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-3">
-                    <div className="text-xl font-bold text-gray-900 font-mono">{departure.time}</div>
-                    <div className="text-base text-gray-700 font-mono font-medium">[{departure.mission}]</div>
+                  <div>
+                    <div className="text-xl font-bold text-gray-900 font-mono">{journey.departure_time}</div>
+                    <div className="text-sm text-gray-500 font-mono">→ {journey.arrival_time}</div>
                   </div>
-                  <div>{getStatusBadge(departure)}</div>
+                  <div className="text-base text-gray-700 font-mono font-medium">
+                    [{journey.mission}] {journey.trip}
+                  </div>
                 </div>
               </CardContent>
             </Card>


### PR DESCRIPTION
## Summary
- fix stop area IDs for Issy-Val-de-Seine and Versailles Château Rive Gauche
- query SNCF journeys API for next 6 direct RER C trains and expose mission, line, trip, departure/arrival times and duration
- adjust frontend and docs for new response format and SNCF_API_KEY

## Testing
- `pnpm lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bc55704b78832fac1139c2028485da