### PR TITLE
Show realtime delays and clean train info

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,6 +14,7 @@ interface TrainJourney {
   arrival: string
   arrival_time: string
   duration_s: number
+  delay_min: number
 }
 
 export default function RERSchedule() {
@@ -94,7 +95,10 @@ export default function RERSchedule() {
                     <div className="text-sm text-gray-500 font-mono">→ {journey.arrival_time}</div>
                   </div>
                   <div className="text-base text-gray-700 font-mono font-medium">
-                    [{journey.mission}] {journey.trip}
+                    [{journey.mission}]
+                    {journey.delay_min > 0 && (
+                      <span className="text-red-600"> (+{journey.delay_min}min)</span>
+                    )}
                   </div>
                 </div>
               </CardContent>


### PR DESCRIPTION
## Summary
- query SNCF API with realtime freshness
- compute delay from realtime vs base schedule times
- show delay in red and hide circulation number

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Requires interactive setup)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bc5ef2c4c8832f9fdaaebd80e41cd8